### PR TITLE
Add .cls and .frm file extensions for VBA

### DIFF
--- a/VBScript.tmLanguage
+++ b/VBScript.tmLanguage
@@ -9,6 +9,8 @@
 		<string>vbs</string>
 		<string>vba</string>
 		<string>bas</string>
+		<string>cls</string>
+		<string>frm</string>
 		<string>vbe</string>
 		<string>wsf</string>
 		<string>wsc</string>


### PR DESCRIPTION
Now that the .vba and .bas extensions have been added, why not also the .cls (VBA class) and .frm (VBA form) extensions? These can be imported and exported from the Microsoft Office VBA editor.